### PR TITLE
Added action to clear the value of a field

### DIFF
--- a/src/main/java/com/datamelt/rules/core/action/StringAction.java
+++ b/src/main/java/com/datamelt/rules/core/action/StringAction.java
@@ -839,4 +839,19 @@ class StringAction extends GenericAction
 			return value;
 		}
 	}
+	
+	/**
+	 * Clears the value of a field
+	 * 
+	 * returns an empty string
+	 * 
+	 *
+	 * @param action	the action to use
+	 * @return			the empty string
+	 */
+	@ActionAnnotation(description= "Clears a value",methodDisplayname="clear value")
+	public String clearValue(XmlAction action)
+	{
+		return "";
+	}
 }


### PR DESCRIPTION
Because the web maintenance tool does not allow empty values to be set without a major rework I added this method to clear the value of a field.