### PR TITLE
Added an exception case to prevent a NullPointer when checking if the value is empty

### DIFF
--- a/src/main/java/com/datamelt/rules/core/RuleSubGroup.java
+++ b/src/main/java/com/datamelt/rules/core/RuleSubGroup.java
@@ -274,7 +274,7 @@ public class RuleSubGroup implements Serializable
                 executionResult.setResultObject2(result2);
                 
                 // here is the exception
-                if (rule.getCheckToExecute().equals("com.datamelt.rules.implementation.CheckIsNull"))
+                if (rule.getCheckToExecute().equals("com.datamelt.rules.implementation.CheckIsNull") || rule.getCheckToExecute().equals("com.datamelt.rules.implementation.CheckIsEmpty"))
                 {
                 	executionResult.getRule().setFailed(0);
                 	executionCollection.increaseRulesPassedCount();


### PR DESCRIPTION
A null value in Pentaho is also a null value in the businessruleengine. If you try to check if the value if empty you receive a NullPointerException.
This mitigates this problem.

We also have to implement a case for the CheckIsNotEmpty somewhere, but I'm currently not sure where.